### PR TITLE
Rails 4 Incompatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 rvm:
-  - 1.8.7 # (current default)
-  - 1.9.2
+  - 1.9.3 # (current default)
+  - 2.0.0
+branches:
+  only:
+    - master
+    - rails_4
 before_script:
   - "psql -c 'create database birthday_plugin_test;' -U postgres"
   - "mysql -e 'create database birthday_plugin_test;'"
-  - "gem install rails -v 3.0.9"
-  - "gem install rails -v 2.3.8"
+  - "gem install rails -v 3.2.14"
+  - "gem install rails -v 4.0.0"
 env:
-  - DB=mysql RAILS=3.0.9
-  - DB=postgres RAILS=3.0.9
-  - DB=mysql RAILS=2.3.8
-  - DB=postgres RAILS=2.3.8
+  - DB=mysql RAILS=4.0.0
+  - DB=postgres RAILS=4.0.0
+  - DB=mysql RAILS=3.2.14
+  - DB=postgres RAILS=3.2.14

--- a/lib/railslove/acts/birthday/birthday.rb
+++ b/lib/railslove/acts/birthday/birthday.rb
@@ -28,7 +28,7 @@ module Railslove
         #   person.created_at_today? => true/false
         def acts_as_birthday(*birthday_fields)
 
-          scope_method = ActiveRecord::VERSION::MAJOR == 3 ? 'scope' : 'named_scope'
+          scope_method = ActiveRecord::VERSION::MAJOR >= 3 ? 'scope' : 'named_scope'
 
           birthday_fields.each do |field|
             self.send(scope_method, :"find_#{field.to_s.pluralize}_for", lambda{ |*scope_args|

--- a/lib/railslove/acts/birthday/birthday.rb
+++ b/lib/railslove/acts/birthday/birthday.rb
@@ -34,7 +34,7 @@ module Railslove
             self.send(scope_method, :"find_#{field.to_s.pluralize}_for", lambda{ |*scope_args|
               raise ArgumentError if scope_args.empty? or scope_args.size > 2
               date_start, date_end = *scope_args
-              ::Railslove::Acts::Birthday::Adapter.adapter_for(self.connection).scope_hash(field, date_start, date_end)
+              where ::Railslove::Acts::Birthday::Adapter.adapter_for(self.connection).scope_hash(field, date_start, date_end)[:conditions]
             })
 
             self.send(scope_method, :"#{field.to_s}_today", lambda{ self.send(:"find_#{field.to_s.pluralize}_for", Date.today) })


### PR DESCRIPTION
Fixes for the following issues with Rails 4.
- acts_as_birthday should call "scope" method instead of "named_scope" which causes method_missing exception.
- acts_as_birthday should return a scope object instead of a hash which has been deprecated.
