### PR TITLE
Named fields

### DIFF
--- a/lib/railslove/acts/birthday/adapter/mysql_adapter.rb
+++ b/lib/railslove/acts/birthday/adapter/mysql_adapter.rb
@@ -7,16 +7,16 @@ module Railslove
           def self.scope_hash(field, date_start, date_end)
             date_start = date_start.to_date
             if ((date_end.respond_to?(:empty?) && date_end.empty?) || !date_end)
-              where_sql = "DATE_FORMAT(`#{field}`, '%m%d') = \"#{date_start.strftime('%m%d')}\""
+              where_sql = "DATE_FORMAT(#{field}, '%m%d') = \"#{date_start.strftime('%m%d')}\""
             else
               date_end = date_end.to_date
               if date_end.strftime('%m%d') < date_start.strftime('%m%d')
-                where_sql = "(DATE_FORMAT(`#{field}`, '%m%d') >= \"0101\""
-                where_sql << " AND DATE_FORMAT(`#{field}`, '%m%d') <= \"#{date_start.strftime('%m%d')}\")"
-                where_sql << " OR (DATE_FORMAT(`#{field}`, '%m%d') >= \"#{date_end.strftime('%m%d')}\""
-                where_sql << " AND DATE_FORMAT(`#{field}`, '%m%d') <= \"1231\")"
+                where_sql = "(DATE_FORMAT(#{field}, '%m%d') >= \"0101\""
+                where_sql << " AND DATE_FORMAT(#{field}, '%m%d') <= \"#{date_end.strftime('%m%d')}\")"
+                where_sql << " OR (DATE_FORMAT(#{field}, '%m%d') >= \"#{date_start.strftime('%m%d')}\""
+                where_sql << " AND DATE_FORMAT(#{field}, '%m%d') <= \"1231\")"
               else
-                where_sql = "DATE_FORMAT(`#{field}`, '%m%d') >= \"#{date_start.strftime('%m%d')}\" AND DATE_FORMAT(`#{field}`, '%m%d') <= \"#{date_end.strftime('%m%d')}\""
+                where_sql = "DATE_FORMAT(#{field}, '%m%d') >= \"#{date_start.strftime('%m%d')}\" AND DATE_FORMAT(#{field}, '%m%d') <= \"#{date_end.strftime('%m%d')}\""
               end
             end
             { :conditions => where_sql }

--- a/lib/railslove/acts/birthday/birthday.rb
+++ b/lib/railslove/acts/birthday/birthday.rb
@@ -31,7 +31,8 @@ module Railslove
           scope_method = ActiveRecord::VERSION::MAJOR >= 3 ? 'scope' : 'named_scope'
 
           birthday_fields.each do |field|
-            name, field = field.is_a?(Hash) ? field.keys.first, field.values.first : field, field
+            name, field = field, field
+            name, field = field.keys.first, field.values.first if field.is_a?(Hash)
             self.send(scope_method, :"find_#{name.to_s.pluralize}_for", lambda{ |*scope_args|
               raise ArgumentError if scope_args.empty? or scope_args.size > 2
               date_start, date_end = *scope_args


### PR DESCRIPTION
I needed to have a name for methods different for the field name used in queries. In my example I needed anniversary to be from the field named "hire_date" which I later refactored for rehires to "last_hire" and "orig_hire". Now you can pass named parameters with the key being the name used in methods and the value being what you want inserted in the query as follows:

```ruby
acts_as_birthday(:birthday, anniversary: '(coalesce(last_hire, orig_hire))')
````

I did take out the back tics around the field name in the mysql adapter where query which is the adapter I am currently using. I have not rewritten for the other adapters.